### PR TITLE
Add files via upload

### DIFF
--- a/Button_Setup.pde
+++ b/Button_Setup.pde
@@ -21,11 +21,11 @@ int[] bY1 = new int[totalButtons]; // stores the top left Y coordinate of all th
 int[] bX2 = new int[totalButtons]; // stores the bottom right X coordinate of all the buttons
 int[] bY2 = new int[totalButtons]; // stores the bottom right Y coordinate of all the buttons
 String[] bText = new String[totalButtons]; // stores the text of all of the buttons
-boolean[] bPress = new boolean[totalButtons]; // bPress means the cursor is over the button & left button is being pressed
-boolean[] bHeld = new boolean[totalButtons]; // bHeld means you've actioned the button but kept the mouse pressed (prevents rapid toggling)
-boolean[] bActive = new boolean[totalButtons]; // bActive means the buttons function is applied
+boolean[] bPress = new boolean[totalButtons]; // true when the cursor is over the button & left mouse button is being pressed
+boolean[] bHeld = new boolean[totalButtons]; // true when you've actioned the button but kept the mouse pressed (prevents rapid toggling)
+boolean[] bActive = new boolean[totalButtons]; // true when the button's function is applied e.g., ignoring transients or 2-windows in use
 
-boolean startNext = false; // if True instructs the program only to start timing when a new phase is entered
+boolean startNext = false; // if True it instructs the program only to start timing when a new phase is entered
 
 void defineButtons(){
 // assign values to the "normal" buttons (1 to 8)
@@ -80,7 +80,7 @@ void defineButtons(){
   
   // define button six (Alter Scale)
   bX1[5] = bX1[3]; // top left corner (x)
-  bY1[5] = progHeight -55; // top left corner (y)
+  bY1[5] = bY2[3] + 15; // top left corner (y)
   bX2[5] = bX1[5] + 100; // bottom right corner (x)
   bY2[5] = bY1[5] + 30; // bottom right corner (y)
   bPress[5] = false;

--- a/Calibrate.pde
+++ b/Calibrate.pde
@@ -1,7 +1,7 @@
 // declare the variables used primarily to calibrate the pressure sensor
-boolean enter = false; // shows if the enter key has been pressed, this is often used to progress the calibration
-boolean suggested = false; // shows if a number has already been suggested to the user
-boolean high = true; // states whether the current calibration is high (true) or low (false)
+boolean enter = false; // true if the enter key has been pressed, this is often used to progress the calibration
+boolean suggested = false; // true if a number has already been suggested to the user
+boolean high = true; // true if the current calibration is high, otherwise it will be flaseM
 int blueShade = 140; // defines the shade of blue used to display the calibration instructional text
 int calStage = -1; //stores the current stage of calibration the user is at (-1 means calibraiton not in progress)
 float[] minRaw = new float[nConfigs]; // stores the minimum raw calibration value (0 is minimum)

--- a/File_Op.pde
+++ b/File_Op.pde
@@ -7,7 +7,7 @@ String[] range = {"Range: low", "Range : high"}; //
 String[] calData = new String[nConfigs]; // stores the config data as strings which can be saved to file, or loaded from file
 String dataFileStamp; // stores the time and date stamp which shall be used in the file name
 PrintWriter outputData; // sets up a file which can be written to on the fly to record timing data
-PrintWriter outputMs; // sets up a file which can be written to live with the time stamps of the data read
+
 
 void saveCalData() { // the code used to save the current calibration data
 // the saving function works by writing an array (set) of text stings to a text file. The data of each dataset are
@@ -67,14 +67,4 @@ void startRecording() {
 void stopRecording() {
   outputData.flush(); // Writes the remaining data to the file
   outputData.close(); // Finishes (closes) the file
-}
-
-void startRecStamps() {
-  dataFileStamp = nf(day(),2,0) + "-" + nf(month(),2,0) + "-" + year() + " @ " + nf(hour(),2,0) + "-" + nf(minute(),2,0) + "_" + nf(second(),2,0); 
-  outputMs = createWriter("Stamps from " + dataFileStamp + ".txt"); // creates a new output file for the timing data
-}
-
-void stopRecStamps() {
-  outputMs.flush(); // Writes the remaining data to the file
-  outputMs.close(); // Finishes (closes) the file
 }

--- a/Plot_Trace.pde
+++ b/Plot_Trace.pde
@@ -1,5 +1,12 @@
 // declare variables used for drawing the plot
 int traceColour = 10; // defines the colour of the trace when not in a timing window
+int livePressureFill = 255; // defines the fill colour of the live-pressure window
+int livePressureOutline = #0A0ABE; // defines the colour of the live-pressure window outline
+int livePressureText = #0A0ABE; // defines the colour of the live-pressure text
+int livePressureClipped = #BC0B0E; // defines the colour of the pressure when outside working scale
+String livePressure = ""; // stores the output text of the live pressure
+boolean clipped = false; // s
+
 int yPos; // stores the current Y position of the trace (relative to the plot window)
 float xPos = 0; // stores the initial X position of the trace (relative to the plot window), initially 0
 int oldY; // stores the previous recored Y position of the trace (relative to the plot window)
@@ -25,6 +32,7 @@ void drawPlot() { // a function used to draw the pressure plot on the plot windo
      
   strokeCap(SQUARE); // resets sroke cap for rest of the program
   strokeWeight(2); // resets line thickness for rest of the program}
+  displayPressure(); // updates the live pressure display below the scale
 }
 
 void blankAhead(){ // this function draws the blanking box in front of the current trace position & re-draws the scale lines in that area
@@ -56,4 +64,24 @@ void clearPlotArea() { // clear the whole plot area
   fill(plotFill); // set the fill colour to the background colour of the plot
   stroke(plotFill); // set the line colour to the background colour of the plot
   rect (lMargin+1, tMargin, rMargin-2, bMargin); // blanks the whole plot area
+}
+
+void displayPressure() { // displays the live pressure for reference and for calibration verification
+  drawLivePressureBox(); // draws the live pressure box, overwriting previous pressure text
+  livePressure = nfp(truePressure, 0, 2); // truncates the pressure to 2 decimal places
+  if (clipped) fill(livePressureClipped); // sets the colour of the text when the pressure is outside the range of the scale
+  else fill(livePressureText); // sets the colour of the live-pressure text
+  textSize(18); // sets the size of the text for the live pressure
+  text(livePressure, rMargin + 50 - (textWidth(livePressure) / 2), bMargin+70); // displays the live pressure centred in the box
+  
+  livePressure = units[aC]; // sets the live pressure text to that of the current units
+  fill(0); // sets the colour of the live-pressure units text to black
+  textSize(14); // sets the size of the text for the live pressure units
+  text(livePressure, rMargin + 50 - (textWidth(livePressure) / 2), bMargin+90); // displays the live pressure centred in the box
+}
+
+void drawLivePressureBox(){ // called separately so box can be drawn without pressure data at program start
+  fill(livePressureFill); // sets the live pressure box fill colour to the defined colour
+  stroke(livePressureOutline); // sets the live pressure box outline colour to the defined colour
+  rect(rMargin+5, bMargin+44, rMargin+105, bMargin+99); // draws the live pressure box
 }

--- a/Screen_Setup.pde
+++ b/Screen_Setup.pde
@@ -3,13 +3,21 @@ int progWidth = 1366; // defines the width of the entire program window
 int progHeight = 768; // defines the height of the entire program window 
 int plotWidth = pW; // defines  the width of the display window
 int plotHeight = 514; // defines  the height of the display, 514 is due to thickness of trace (was 513)
+
 int lMargin = 40; // defines the width & so the position of the left margin
 int rMargin = lMargin + plotWidth; // defines the position of the right margin (from 0)
 int tMargin = 130; // defines the height & so the position of the top margin
 int bMargin = tMargin + plotHeight; // defines the position of the bottom margin (from 0)
+
 int bgFill = 190; // defines the greyscale colour of the background
 int plotFill = 230; // defines the greyscale colour of the plot window
 int grey = 100; // defines the greyscale colour for greyed out text (must be at least 30)
+
+int buttonFill = 250; // defines the fill colour of the buttons
+int buttonOutline = 100; // defines the colour of the buttons' outline
+int buttonShadow = 40; // defines the colour of the buttons' shadow
+int textActive = #0A0ABE; // defines the colour of the button's text when the button is active
+int textInactive = 0; // defines the colour of the buttons' text when the button is inactive
 
 void screenSetup() { // this is called only during setup at program launch, it builds the screen elements
   background(bgFill); // sets the background fill colour and uses it to fill the screen
@@ -39,6 +47,7 @@ void screenSetup() { // this is called only during setup at program launch, it b
   drawDataCaptions(); // this labels the 3 timing window data areas as Window 1"... Window 3"
   drawMovableWindows(); // this draws the 3 coloured blocks which represent the current timing windows
   updateTimingData(); // this updates the data displayed for each of the 3 timing windows
+  drawLivePressureBox(); // this draws the live pressure display window
 }
 
 void defineWindows() { // this function assigns values to the timing window variables e.g., upper & lower values
@@ -97,24 +106,24 @@ void drawButtons(int lo, int hi) { // draws the button in the range specified e.
 // to be drawn makes the function more flexible as it can draw only the buttons currently required for display
   for (int i = lo; i < hi + 1; i++) { // repeat for number of buttons
     if (!bActive[i]) { // if the button isn't selected draw a shadow
-      fill(20); // sets the fill colour of the shadow
-      stroke(20);
+      fill(buttonShadow); // sets the fill colour of the shadow
+      stroke(buttonShadow);
       rect(bX1[i] + shadow, bY1[i] + shadow, bX2[i] + shadow, bY2[i] + shadow); // draws the button shadow
     } else { // erase any previous shadow by using the background colour
       fill(bgFill); // sets the fill colour of the shadow
       stroke(bgFill);
-      rect(bX1[i] + shadow, bY1[i] + shadow, bX2[i] + shadow, bY2[i] + shadow); // draws the button shadow
+      rect(bX1[i] + shadow, bY1[i] + shadow, bX2[i] + shadow, bY2[i] + shadow); // draws a blank box in place of the shadow
     }
 
-    stroke(100); // sets colour of button perimeter
-    fill(240); // sets fill colour for the button
+    stroke(buttonOutline); // sets colour of button perimeter
+    fill(buttonFill); // sets fill colour for the button
     rect(bX1[i], bY1[i], bX2[i], bY2[i]); // draws the button
 
     if (bActive[i]) { // if the current button is latched (active)...
-      fill(10, 10, 190); // sets the text colour
+      fill(textActive); // sets the text colour to the defined active-text colour
       textSize(16); // sets the text size for the button text
     } else {
-      fill(0); // sets the text colour
+      fill(textInactive); // sets the text colour to the defined inactive-text colour
       textSize(14); // sets the text size for the button text
     }
     text(bText[i], bX1[i] + xOff, bY1[i] + yOff); // draws the button text

--- a/Selections.pde
+++ b/Selections.pde
@@ -204,7 +204,7 @@ void actionButtons() { // take specific actions depending on which button has be
 // specifically deals with button 8 which turns the recording on / off
   // if button 7 is exclusively pressed but wasn't previously
   if (bPress[7] && !bHeld[7] && !otherButton(7)) {
-    bActive[7] = !bActive[7]; // invert the button6 Held
+    bActive[7] = !bActive[7]; // invert the button ACtive status
     bHeld[7] = true; // set the button Held to true meaning it was already pressed and actioned
     
     if (bActive[7]) {
@@ -212,7 +212,6 @@ void actionButtons() { // take specific actions depending on which button has be
       bText[7] = "Stop" + '\n' + "recording";
     } else {
       stopRecording();
-      stopRecStamps();
       bText[7] = "Start" + '\n' + "recording";
     }
   }

--- a/Timing.pde
+++ b/Timing.pde
@@ -1,8 +1,8 @@
 // declare variables used for the selectable windows
 float[] upper = new float[3]; // stores the upper limit of the 3 timing windows (in pressure units)
 float[] lower = new float[3]; // stores the lower limit of the 3 timing windows (in pressure units)
-boolean[] upperDrag = new boolean[3]; // stores the upper line still selected and being dragged
-boolean[] lowerDrag = new boolean[3]; // stores the lower line still selected and being dragged
+boolean[] upperDrag = new boolean[3]; // true if the upper line is still selected and being dragged
+boolean[] lowerDrag = new boolean[3]; // true if the lower line is still selected and being dragged
 float[] winTopY = new float[3]; // stores the upper Y position of the text box (in pixels)
 float[] winBotY = new float[3]; // stores the lower Y position of the text box (in pixels)
 byte nWin = 3; // stores the number of currently active windows, used in "for loops" processing window actions, default is 3
@@ -23,11 +23,11 @@ int[] start = new int[3]; // stores the window start time for the 3 timing windo
 int[] average = new int[3]; // stores the average cycle time for the 3 timing windows
 int[] count = new int[3]; // stores the number of timing cycles measured for each of the 3 timing windows
 float[] totTime = new float[3]; // stores the accumulated total time spent within the monitored window, for each of 3 windows 
-boolean[] winActive = new boolean[3]; // stores the current status of the 3 timing windows (active if timing already begun)
-boolean[] ignoring = new boolean[3]; // stores the current status of the 3 timing windows
+boolean[] winActive = new boolean[3]; // true if the timing windows is currently active i.e., if timing already begun)
+boolean[] ignoring = new boolean[3]; // true if the timing windows is being ignored because the time < transient period
 int transTime = 100; // defines the duration in ms of transient timings which are to be ignored
-boolean ignore = true; // true if transients are being ignored (tidier than using the button's active variable)
-boolean updateStartNextButton = false; // the button can't be drawn within timing as is outside the draw loop - this flags it to be done
+boolean ignore = true; // mirrors the current windows ifnoring flag (shorter syntax that referencing actual flag)
+boolean updateStartNextButton = false; // when true if flags the button to be refreshed within the draw loop 
 
 void timing() { // acquire & set time stamps when the current pressure is within a monitored window (range)
   for (byte i =0; i<nWin; i++) { // repeat for the number of active pressure windows
@@ -61,10 +61,11 @@ void timing() { // acquire & set time stamps when the current pressure is within
         totTime[i] += msTime[i]; // increments the total time for this window by the current time (only when pressure exits the window)
         average[i] = round(totTime[i] / count[i]); // updates the average time by dividing total time by cycle count
         
-        if (!ignoring[i] && bActive[7]) { // if not ignoring this timing e.g., due to it being transient, and it's being recorded...
+        // if not ignoring this timing e.g., due to it being transient, and it's being recorded, and not waiting for the next cycle...
+        if (!ignoring[i] && bActive[7] && !bActive[6]) {
           // writes the phase number (1,2,3) and the measured phase time (to the nearest 100th of a second) to a new line in the file
           timeStamp = round(msTime[i]/10.0);
-          timeStamp = timeStamp / 100; // if done in one line then it truncates to the nearest second for some reason
+          timeStamp = timeStamp / 100; // if done in one line then it truncates to the nearest second as acting as an integer
           outputData.println(i+1 + "," + timeStamp);
         }
       }

--- a/Which tab functions are in.txt
+++ b/Which tab functions are in.txt
@@ -19,11 +19,13 @@ BUTTON_SETUP tab
 
 CALIBRATE tab
 	drawCalScreen
+	setRange
 	setUnits
 	requestPressure
 	getPressure
 	setScaleLimits
 	askDaveData
+	askLoadData
 	exitCalibration
 	suggestValue
 	keyReleased
@@ -34,13 +36,13 @@ FILE_OP tab
 	listCalData
 	startRecording
 	stopRecording
-	startRecStamps
-	stopRecStamps
 
 PLOT_TRACE tab
 	drawPlot
 	blankAhead
 	clearPlotArea
+	displayPressure
+	drawLivePressureBox
 
 SCALES tab
 	drawScales
@@ -62,7 +64,7 @@ SELECTIONS tab
 	checkWinowDrag
 	actionButtons
 	clearWinArea
-otherButton
+	otherButton
 
 TIMING tab
 	timing


### PR DESCRIPTION
Add live pressure value display which can be used in accuracy checking.
Include a function to highlight the live pressure in red when under or over scale limits.
Fixed a minor bug which meant that if waiting for the phase to change before starting the timing, a first entry of 0.0s could be recorded in the output file, if recording was selected and the pressure started within a timing window.
Removed the time stamps code as it was only required for development