### PR TITLE
Add files via upload

### DIFF
--- a/Master_Program.pde
+++ b/Master_Program.pde
@@ -70,6 +70,7 @@ void draw() {
   }
   else if (msNow > msStart + startDelay){ // if not in any special mode & not in start-up delay, draw usual screen
     advanceTrace();  // progress the X position of the trace
+    displayPressure(); // updates the live pressure display below the scale
     drawScales(); // refresh the left & right scales as the plot line thickness means it can encroach over them
   }
   

--- a/Plot_Trace.pde
+++ b/Plot_Trace.pde
@@ -1,4 +1,7 @@
 // declare variables used for drawing the plot
+byte damping = 20; // defines how many frames to count before updating the live pressure - acts to damp the reading
+byte dampingCounter = 0; // stores the current frame count, when equal to 'damping' the pressure will update
+float greatest; // stores the highest magnitude value of the 2 scales i.e., of -30 and + 20 the value stored will be +30
 int traceColour = 10; // defines the colour of the trace when not in a timing window
 int livePressureFill = 255; // defines the fill colour of the live-pressure window
 int livePressureOutline = #0A0ABE; // defines the colour of the live-pressure window outline
@@ -32,7 +35,6 @@ void drawPlot() { // a function used to draw the pressure plot on the plot windo
      
   strokeCap(SQUARE); // resets sroke cap for rest of the program
   strokeWeight(2); // resets line thickness for rest of the program}
-  displayPressure(); // updates the live pressure display below the scale
 }
 
 void blankAhead(){ // this function draws the blanking box in front of the current trace position & re-draws the scale lines in that area
@@ -67,21 +69,34 @@ void clearPlotArea() { // clear the whole plot area
 }
 
 void displayPressure() { // displays the live pressure for reference and for calibration verification
-  drawLivePressureBox(); // draws the live pressure box, overwriting previous pressure text
-  livePressure = nfp(truePressure, 0, 2); // truncates the pressure to 2 decimal places
-  if (clipped) fill(livePressureClipped); // sets the colour of the text when the pressure is outside the range of the scale
-  else fill(livePressureText); // sets the colour of the live-pressure text
-  textSize(18); // sets the size of the text for the live pressure
-  text(livePressure, rMargin + 50 - (textWidth(livePressure) / 2), bMargin+60); // displays the live pressure centred in the box
-  
-  livePressure = units[aC]; // sets the live pressure text to that of the current units
-  fill(0); // sets the colour of the live-pressure units text to black
-  textSize(14); // sets the size of the text for the live pressure units
-  text(livePressure, rMargin + 50 - (textWidth(livePressure) / 2), bMargin+80); // displays the live pressure centred in the box
+  dampingCounter ++; // increment the damping counter by 1
+  if (dampingCounter == damping) {
+    dampingCounter = 0; // reset the damping counter
+    
+    drawLivePressureBox(); // draws the live pressure box, overwriting previous pressure text
+    
+    greatest = abs(lScale[aC]);
+    if (greatest < abs(uScale[aC])) greatest = uScale[aC];
+    if (greatest < 10 ) livePressure = nfp(truePressure, 0, 2); // #.xx
+    else
+    if (greatest < 100) livePressure = nfp(truePressure, 0, 1); // #.x
+    else
+    livePressure = nfp(round(truePressure), 0, 0); // #
+    
+    if (clipped) fill(livePressureClipped); // sets the colour of the text when the pressure is outside the range of the scale
+    else fill(livePressureText); // sets the colour of the live-pressure text
+    textSize(18); // sets the size of the text for the live pressure
+    text(livePressure, rMargin + 50 - (textWidth(livePressure) / 2), bMargin+60); // displays the live pressure centred in the box
+    
+    livePressure = units[aC]; // sets the live pressure text to that of the current units
+    fill(0); // sets the colour of the live-pressure units text to black
+    textSize(14); // sets the size of the text for the live pressure units
+    text(livePressure, rMargin + 50 - (textWidth(livePressure) / 2), bMargin+80); // displays the live pressure centred in the box
+  }
 }
 
 void drawLivePressureBox(){ // called separately so box can be drawn without pressure data at program start
-  fill(livePressureFill); // sets the live pressure box fill colour to the defined colour
-  stroke(livePressureOutline); // sets the live pressure box outline colour to the defined colour
-  rect(rMargin+5, bMargin+40, rMargin+105, bMargin+87); // draws the live pressure box
+    fill(livePressureFill); // sets the live pressure box fill colour to the defined colour
+    stroke(livePressureOutline); // sets the live pressure box outline colour to the defined colour
+    rect(rMargin+5, bMargin+40, rMargin+105, bMargin+87); // draws the live pressure box
 }

--- a/Timing.pde
+++ b/Timing.pde
@@ -27,7 +27,7 @@ float[] totTime = new float[3]; // stores the accumulated total time spent withi
 boolean[] winActive = new boolean[3]; // true if the timing windows is currently active i.e., if timing already begun)
 boolean[] ignoring = new boolean[3]; // true if the timing windows is being ignored because the time < transient period
 int transTime = 100; // defines the duration in ms of transient timings which are to be ignored
-boolean ignore = true; // mirrors the current windows ifnoring flag (shorter syntax that referencing actual flag)
+boolean ignore = false; // mirrors the current windows ifnoring flag (shorter syntax that referencing actual flag)
 boolean updateStartNextButton = false; // when true if flags the button to be refreshed within the draw loop 
 
 void timing() { // acquire & set time stamps when the current pressure is within a monitored window (range)
@@ -59,8 +59,9 @@ void timing() { // acquire & set time stamps when the current pressure is within
     } else { // if the current pressure is outside the window but was within the window in the last pass then...
         if (winActive[i]) { // if the window was being timed then...
           winActive[i] = false; // set the window timing status to inactive
-  
+            
           if (!startNext) { // if not watinig for a cycle change before beginning the timing...
+            msTime[i] = msNow2 - start[i]; // increase the timing duration of the window
             count[i] ++; // increase the number of cycles which have been counted for this window
             totTime[i] += msTime[i]; // increments the total time for this window by the current time (only when pressure exits the window)
             average[i] = round(totTime[i] / count[i]); // updates the average time by dividing total time by cycle count


### PR DESCRIPTION
Prior to verifying pressure accuracy, and from observations using the program, I have dampened the refresh rate of the live pressure display. It is customisable in a variable within the source code (but not from within the program) and at default is set to 3 per second. I also scaled the live pressure reading to #.xx if the highest absolute scale magnitude is <10, or to #.x between 10 & 100, and to just # (no decimal places) above 100.
Finally, I took the opportunity to fix a minor bug in the timing readout; if the pressure was in-range but waiting for a new cycle before starting the timing, when the pressure left the current window, the total time the program had waited with the pressure in-range would be displayed in that timing window until overwritten. It did not contribute to any real totals or averages.